### PR TITLE
link: replace mentor-available with confirmed-bug

### DIFF
--- a/next-steps/index.html
+++ b/next-steps/index.html
@@ -30,10 +30,10 @@
 
           <li>Search for <a href="https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22">open issues labeled "help wanted"</a> in the issue tracker.</li>
 
-          <li>Search for <a href="https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3Amentor-available">open issues labeled "mentor-available"</a> in the issue tracker.</li>
-
           <li>Search for <a href="https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+sort%3Acreated-asc">open issues that are more than a week old and labeled "good first issue"</a> in the issue tracker.</li>
 
+          <li>Search for <a href="https://github.com/nodejs/node/issues?q=is%3Aissue+is%3Aopen+label%3Aconfirmed-bug">open issues labeled "confirmed-bug"</a> in the issue tracker.</li>
+          
           <li>If you are feeling a little ambitious, check out <i>backlog/orphan</i> column of <a href="https://github.com/nodejs/node/projects/13">the project board for feature requests</a>. See if there's anything there you might want to try to implement.</li> 
           
           <li>A lot of our tooling is in Python. If you know Python, there are almost always a few <a href="https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3Apython">issues with the "python" label</a> that you might be able to help with!</li>


### PR DESCRIPTION
It seems that the `mentor-available` tag is no longer used and `confirmed-bug` is a better choice for developers who want to contribute code to Node

BTW, NodeTodo has helped me a lot and I'm very thankful for the existence of this site!